### PR TITLE
[BUGFIX] fix undefined method call in WebDav/Nodes/Fal/File

### DIFF
--- a/Classes/WebDav/Nodes/Fal/File.php
+++ b/Classes/WebDav/Nodes/Fal/File.php
@@ -112,7 +112,7 @@ class File extends \Sabre_DAV_File {
 	 * @param string $name
 	 */
 	public function setName($name) {
-		$this->file->setName($name);
+		$this->file->rename($name);
 	}
 
 	/**


### PR DESCRIPTION
Error: Call to undefined method TYPO3\CMS\Core\Resource\File::setName()

The fal file object does only allow to rename a file but not set a name.
